### PR TITLE
Fix istio ingressGateways on istio 1.7

### DIFF
--- a/kind/install-istio.yaml
+++ b/kind/install-istio.yaml
@@ -14,7 +14,8 @@ spec:
     cni:
       enabled: true
     ingressGateways:
-    - enabled: true
+    - name: istio-ingressgateway
+      enabled: true
       k8s:
         hpaSpec:
           maxReplicas: 1


### PR DESCRIPTION
In istio 1.7 ingressGateway need a name.
Tested on: 
kind version 0.9.0
kubernetes 1.19.1
istio 1.7.3